### PR TITLE
Calculate number of runners differently

### DIFF
--- a/src/components/StatBar.vue
+++ b/src/components/StatBar.vue
@@ -7,7 +7,7 @@
             {{location.name}}
           </v-card-text>
           <v-card-text class="ma-1 pa-0 headline text-xs-center">
-            {{location.numberOfRunners}}
+            {{numOfRunnersInLocation(location)}}
           </v-card-text>
           <v-card-text v-if="location.cutoff != null" class="pa-1 ma-1 text-xs-center">
             {{location.timeLeft}}
@@ -24,7 +24,12 @@ export default {
   name: 'StatBar',
   props: ['arrayBegin', 'arrayEnd'],
   created() {
-    this.$store.dispatch('timeLeft'), this.$store.dispatch('numberOfRunners')
+    this.$store.dispatch('timeLeft')
+  },
+  methods: {
+    numOfRunnersInLocation(location) {
+      return this.$store.getters.numOfRunnersInLocation(location.code)
+    },
   },
   computed: {
     ...mapState(['locations']),

--- a/src/store.js
+++ b/src/store.js
@@ -198,7 +198,7 @@ export default new Vuex.Store({
       state.runners = payload
     },
     timeLeft(state) {
-      return state.locations.map(location => {
+      return state.locations.forEach(location => {
         const now = moment()
         const end = moment(location.cutoff)
         const duration = moment.duration(end.diff(now))
@@ -211,181 +211,6 @@ export default new Vuex.Store({
           .toString()
           .padStart(2, '0')}`
       })
-    },
-    zoneOneRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z1')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneOne.length
-        })
-    },
-    zoneTwoRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z2')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneTwo.length
-        })
-    },
-    zoneThreeRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z3')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneThree.length
-        })
-    },
-    zoneFourRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z4')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneFour.length
-        })
-    },
-    zoneFiveRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z5')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneFive.length
-        })
-    },
-    zoneSixRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z6')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneSix.length
-        })
-    },
-    zoneSevenRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z7')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneSeven.length
-        })
-    },
-    zoneEightRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z8')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneEight.length
-        })
-    },
-    zoneNineRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z9')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneNine.length
-        })
-    },
-    zoneTenRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z10')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneTen.length
-        })
-    },
-    zoneElevenRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z11')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneEleven.length
-        })
-    },
-    zoneTwelveRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z12')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneTwelve.length
-        })
-    },
-    zoneThirteenRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'z13')
-        .map(location => {
-          location.numberOfRunners = this.getters.zoneThirteen.length
-        })
-    },
-    rasberryRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'ra1')
-        .map(location => {
-          location.numberOfRunners = this.getters.rasberry.length
-        })
-    },
-    anteroRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'ant')
-        .map(location => {
-          location.numberOfRunners = this.getters.antero.length
-        })
-    },
-    stElmoRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'ste1')
-        .map(location => {
-          location.numberOfRunners = this.getters.stElmo.length
-        })
-    },
-    cottonwoodRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'cot')
-        .map(location => {
-          location.numberOfRunners = this.getters.cottonwood.length
-        })
-    },
-    stElmoTwoRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'ste2')
-        .map(location => {
-          location.numberOfRunners = this.getters.stElmoTwo.length
-        })
-    },
-    hancockRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'han')
-        .map(location => {
-          location.numberOfRunners = this.getters.hancock.length
-        })
-    },
-    lostWonderRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'los')
-        .map(location => {
-          location.numberOfRunners = this.getters.lostWonder.length
-        })
-    },
-    purgatoryRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'pur')
-        .map(location => {
-          location.numberOfRunners = this.getters.purgatory.length
-        })
-    },
-    monarchRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'mon')
-        .map(location => {
-          location.numberOfRunners = this.getters.monarch.length
-        })
-    },
-    foosesRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'foo')
-        .map(location => {
-          location.numberOfRunners = this.getters.fooses.length
-        })
-    },
-    blanksRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'bla')
-        .map(location => {
-          location.numberOfRunners = this.getters.blanks.length
-        })
-    },
-    rasberryTwoRunners(state) {
-      return state.locations
-        .filter(location => location.code === 'ra2')
-        .map(location => {
-          location.numberOfRunners = this.getters.rasberryTwo.length
-        })
     },
   },
   actions: {
@@ -408,34 +233,6 @@ export default new Vuex.Store({
         store.commit('timeLeft')
       }, 1000)
     },
-    numberOfRunners(store) {
-      setInterval(() => {
-        store.commit('zoneOneRunners')
-        store.commit('zoneTwoRunners')
-        store.commit('zoneThreeRunners')
-        store.commit('zoneFourRunners')
-        store.commit('zoneFiveRunners')
-        store.commit('zoneSixRunners')
-        store.commit('zoneSevenRunners')
-        store.commit('zoneEightRunners')
-        store.commit('zoneNineRunners')
-        store.commit('zoneTenRunners')
-        store.commit('zoneElevenRunners')
-        store.commit('zoneTwelveRunners')
-        store.commit('zoneThirteenRunners')
-        store.commit('rasberryRunners')
-        store.commit('anteroRunners')
-        store.commit('stElmoRunners')
-        store.commit('cottonwoodRunners')
-        store.commit('stElmoTwoRunners')
-        store.commit('hancockRunners')
-        store.commit('lostWonderRunners')
-        store.commit('monarchRunners')
-        store.commit('foosesRunners')
-        store.commit('blanksRunners')
-        store.commit('rasberryTwoRunners')
-      }, 20000)
-    },
   },
   getters: {
     aidStations(state) {
@@ -450,131 +247,40 @@ export default new Vuex.Store({
       if (!state.runners) return null
       return state.runners.find(runner => runner.bibNumber === bibNum)
     },
+    numOfRunnersInLocation: state => locationCode => {
+      let num = 0
+      const location = state.locations.find(l => l.code === locationCode)
 
-    zoneOne: state => {
-      return state.runners.filter(
-        runner => runner.Started === true && runner.RasberryOneIn === null
-      )
-    },
-    zoneTwo: state => {
-      return state.runners.filter(
-        runner => runner.RasberryOut != null && runner.AnteroIn === null
-      )
-    },
-    zoneThree: state => {
-      return state.runners.filter(
-        runner => runner.AnteroOut != null && runner.StElmoOneIn === null
-      )
-    },
-    zoneFour: state => {
-      return state.runners.filter(
-        runner => runner.StElmoOneOut != null && runner.CottonwoodIn === null
-      )
-    },
-    zoneFive: state => {
-      return state.runners.filter(
-        runner => runner.CottonwoodOut != null && runner.StElmoTwoIn === null
-      )
-    },
-    zoneSix: state => {
-      return state.runners.filter(
-        runner => runner.StElmoTwoOut != null && runner.HancockIn === null
-      )
-    },
-    zoneSeven: state => {
-      return state.runners.filter(
-        runner => runner.HancockOut != null && runner.LostWonderIn === null
-      )
-    },
-    zoneEight: state => {
-      return state.runners.filter(
-        runner => runner.LostWonderOut != null && runner.PurgatoryIn === null
-      )
-    },
-    zoneNine: state => {
-      return state.runners.filter(
-        runner => runner.PurgatoryOut != null && runner.MonarchIn === null
-      )
-    },
-    zoneTen: state => {
-      return state.runners.filter(
-        runner => runner.MonarchOut != null && runner.FoosesIn === null
-      )
-    },
-    zoneEleven: state => {
-      return state.runners.filter(
-        runner => runner.FoosesOut != null && runner.BlanksIn === null
-      )
-    },
-    zoneTwelve: state => {
-      return state.runners.filter(
-        runner => runner.BlanksOut != null && runner.RasberryTwoIn === null
-      )
-    },
-    zoneThirteen: state => {
-      return state.runners.filter(
-        runner => runner.RasberryTwoOut != null && runner.Finish === null
-      )
-    },
-    rasberry: state => {
-      return state.runners.filter(
-        runner => runner.RasberryOneIn != null && runner.RasberryOneOut === null
-      )
-    },
-    antero: state => {
-      return state.runners.filter(
-        runner => runner.AnteroIn != null && runner.AnteroOut === null
-      )
-    },
-    stElmo: state => {
-      return state.runners.filter(
-        runner => runner.StElmoOneIn != null && runner.StElmoOneOut === null
-      )
-    },
-    cottonwood: state => {
-      return state.runners.filter(
-        runner => runner.CottonwoodIn != null && runner.CottonwoodOut === null
-      )
-    },
-    stElmoTwo: state => {
-      return state.runners.filter(
-        runner => runner.StElmoTwoIn != null && runner.StElmoTwoOut === null
-      )
-    },
-    hancock: state => {
-      return state.runners.filter(
-        runner => runner.HancockIn != null && runner.HancockOut === null
-      )
-    },
-    lostWonder: state => {
-      return state.runners.filter(
-        runner => runner.LostWonderIn != null && runner.LostWonderOut === null
-      )
-    },
-    purgatory: state => {
-      return state.runners.filter(
-        runner => runner.PurgatoryIn != null && runner.PurgatoryOut === null
-      )
-    },
-    monarch: state => {
-      return state.runners.filter(
-        runner => runner.MonarchIn != null && runner.MonarchOut === null
-      )
-    },
-    fooses: state => {
-      return state.runners.filter(
-        runner => runner.FoosesIn != null && runner.FoosesOut === null
-      )
-    },
-    blanks: state => {
-      return state.runners.filter(
-        runner => runner.BlanksIn != null && runner.BlanksOut === null
-      )
-    },
-    rasberryTwo: state => {
-      return state.runners.filter(
-        runner => runner.RasberryTwoIn != null && runner.RasberryTwoOut === null
-      )
+      const index = state.locations.indexOf(location)
+
+      state.runners.forEach(runner => {
+        if (location.type === 'aidStation') {
+          const locationName = location.name
+            .replace(/ /g, '')
+            .replace(/\./g, '')
+
+          if (
+            runner[`${locationName}In`] != null &&
+            runner[`${locationName}Out` === null]
+          ) {
+            num++
+          }
+        } else {
+          let zoneStart =
+            index === 0 ? 'Started' : `${state.locations[index - 1].name}Out`
+          let zoneEnd =
+            index === state.locations.length - 1
+              ? 'Finish'
+              : `${state.locations[index + 1].name}Out`
+          zoneStart = zoneStart.replace(/ /g, '').replace(/\./g, '')
+          zoneEnd = zoneEnd.replace(/ /g, '').replace(/\./g, '')
+
+          if (runner[zoneStart] != null && runner[zoneEnd] === null) {
+            num++
+          }
+        }
+      })
+      return num
     },
   },
 })


### PR DESCRIPTION
https://github.com/bmj1985/hl100raceapp/blob/65fdf93e306678bb5db6861fff6c5c23b0fc06b0/src/store.js#L215

We are trying to keep track of the # of runners in each location.  We don't need mutations plus actions to update this property.  The only action/mutation we really have is updating the list of runners from the database.  How many runners are in a particular category can be computed on the fly and is essential the length of these getters.

`    zoneOne: state => {
      return state.runners.filter(
        runner => runner.Started === true && runner.RasberryOneIn === null
      )
    },
`

Just letting you know because what you are doing is setting an observable based on the value of the getter (which is a computed value) which is updated from an action/mutation which updates the same getter.  It's a bit convoluted.

What we might be able to do is what I have done here in this pull request: simply use a function that returns the num of runners for a location that simply loops through all runners and checks the ones that have an in time but no out time for the requested location.